### PR TITLE
Implement safe randomness example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "casino"
+version = "0.1.0"
+authors = ["InkDevHub"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4.2.0", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
+
+dia-oracle-randomness-getter = { path = "oracle-randomness-getter", default-features = false }
+dia-oracle-randomness-type = { path = "oracle-randomness-type", default-features = false }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "dia-oracle-randomness-getter/std",
+    "dia-oracle-randomness-type/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Safe Randomness in Smart Contracts: A Tutorial
+
+This tutorial aims to clarify the importance of secure randomness generation in smart contracts. We demonstrate why the commonly used approach is unsafe and introduce a safer alternative using an oracle.
+
+## Motivation
+
+### Unsafe Pattern:
+
+Problem: Consider a simple Casino contract with a coin_toss function (implementation details are irrelevant). The play function allows users to play by paying a fee. The outcome of the coin_toss determines whether the user wins or loses.
+```Rust
+fn coin_toss(&mut self) -> bool {
+	//Some logic to implement randomness
+}
+
+#[ink(message)]
+pub fn play(&mut self) {
+	// The player pays the fee to the Casino for playing.
+
+    let toss = self.coin_toss();
+    if toss {
+    	// player wins -- they get some token
+    } else {
+    	// player loses
+    }
+}
+```
+
+### Why is coin_toss unsafe?
+
+The issue lies in attempting to generate random numbers within the contract itself. Common methods like using blockhash, timestamp, or internal state are all ultimately predictable and manipulable. This predictability allows users to exploit the system as explained earlier.
+
+While users pay the fee for playing, they can exploit this pattern. Instead of directly playing the game, a malicious user can create a contract that checks the outcome of play without actually playing. If they lose, the transaction is reverted, costing only gas fees. If they win, they keep the winnings. This essentially allows the user to gamble risk-free, exploiting the predictable nature of coin_toss.
+
+```Rust
+#[ink(message)]
+pub fn play_to_win(&mut self) {
+	// call the `play` message from the `Casino` contract
+	let won = // code that checks if there was a win, for instance checking if balance of a particular token increased
+	if !won {
+		panic!("Hehe");
+	}
+}
+```
+
+## Safe Randomness with Oracles
+
+The solution involves utilizing a randomness oracle, a dedicated external service that provides unpredictable and verifiable randomness on-chain. The oracle would push some piece of safe randomness on chain via a smart contract. 
+For example, the [DIA oracle](https://github.com/diadata-org/dia-oracle-anchor/blob/main/example-randomness-oracle/example.rs)
+
+Take a look at the [example implementation.](./lib.rs)
+
+First off, a user registers a bet with `register_bet()` message. It would take a bet fee from a user and save the bet data to the storage.
+
+The message fetches the randomness for that specific round from the oracle:
+```Rust
+#[ink(message)]
+pub fn get_random(&self, key: u64) -> Option<Vec<u8>> {
+    self.oracle.get_random_value_for_round(key)
+}
+```
+Based on the retrieved randomness, the win/loss is determined, rewards are distributed, and the bet is removed by `resolve_bet()` message after waiting for a couple of blocks.
+
+This approach requires two transactions from the user: register_bet and later resolve_bet. While less user-friendly, it ensures fairness and prevents users from exploiting the system.
+
+## Conclusion
+
+Utilizing a randomness oracle is essential for generating secure and unpredictable randomness within smart contracts. This tutorial sheds light on the pitfalls of the unsafe pattern and demonstrates a safer alternative that leverages the power of oracles. Remember, always choose well-established and secure oracles for your smart contract applications.

--- a/lib.rs
+++ b/lib.rs
@@ -1,0 +1,140 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+/// This contract demonstrates a safe approach to handling randomness in smart contracts using an external oracle.
+/// It simulates a simple casino-like game where users can place bets and potentially win rewards.
+/// 
+/// The provided code is for educational purposes only and should not be used in production.
+///
+/// Key Features:
+///
+/// - Integration with a Randomness Oracle: Relies on an external oracle (DIA Oracle in this example) to provide
+///   unpredictable randomness, ensuring fairness.
+/// - Two-Phase Betting:
+///   - register_bet: User registers a bet and pays a fee.
+///   - resolve_bet: User resolves the bet based on the oracle's randomness to determine win/loss and receive rewards.
+///
+/// Contract Structure:
+///
+/// Storage:
+/// bets: Mapping that stores bet details (bet id, round, user).
+/// oracle: Contract reference to the DIA Oracle.
+///
+/// Functionality:
+///
+/// - get_random(key: u64) -> Option<Vec<u8>>: Fetches randomness for a given round from the oracle.
+/// - register_bet() -> Result<(), Error>: Registers a new bet, assigning a future round number, and charging a fee.
+/// - resolve_bet(bet_id: BetId) -> Result<(), Error>: Resolves a bet based on the oracle's randomness,
+///   distributing rewards if applicable.
+///
+/// - get_id() -> BetId: Generates a unique bet identifier.
+/// - pay_fee(user: User) -> Result<(), Error>: Handles fee payment.
+/// - is_victorious(randomness: Vec<u8>) -> bool: Determines if the bet is a win based on randomness.
+/// - pay_reward(user: User) -> Result<(), Error>: Pays out rewards to the user.
+
+#[ink::contract]
+mod casino {
+    use dia_oracle_randomness_getter::RandomOracleGetter;
+    use ink::contract_ref;
+    use ink::prelude::vec::Vec;
+    use ink::storage::Mapping;
+
+    #[derive(Eq, PartialEq, Debug, scale::Encode, scale::Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        FailedTransfer,
+        BetResolutionTooEarly,
+        Custom(Vec<u8>),
+    }
+
+    /// Example helper types
+    pub type BetId = u128;
+    pub type Round = u64;
+    pub type User = AccountId;
+    pub type BetDetails = (Round, User);
+
+    #[ink(storage)]
+    pub struct Casino {
+        bets: Mapping<BetId, BetDetails>,
+        // reference to the oracle contract
+        oracle: contract_ref!(RandomOracleGetter),
+    }
+
+    impl Casino {
+        #[ink(constructor)]
+        pub fn new(oracle_address: AccountId) -> Self {
+            Self {
+                bets: Mapping::default(),
+                oracle: oracle_address.into(),
+            }
+        }
+
+        /// Gets a random value from an oracle.
+        #[ink(message)]
+        pub fn get_random(&self, key: u64) -> Option<Vec<u8>> {
+            self.oracle.get_random_value_for_round(key)
+        }
+
+        /// A user will call the message to place a bet
+        #[ink(message)]
+        pub fn register_bet(&mut self) -> Result<(), Error> {
+            let user = self.env().caller();
+            // The player pays the fee to the Casino for playing.
+            self.pay_fee(user)?;
+
+            let bet_id = self.get_id(); // get a fresh BetId
+            let current_round = self.oracle.get_latest_round();
+            let round = current_round + 2; // we need to make sure this is a round in the future;
+            let details = (round, user);
+            self.bets.insert(bet_id, &details);
+
+            Ok(())
+        }
+
+        /// Depending on the randomness, provided by the oracle, determines if a user is victorious and pays 
+        /// them up in that case. 
+        /// 
+        /// The user needs to wait a couple of blocks after registering a bet before calling this message.
+        #[ink(message)]
+        pub fn resolve_bet(&mut self, bet_id: BetId) -> Result<(), Error> {
+            let user = self.env().caller();
+            let round = self.bets.get(bet_id).unwrap().0;
+            let randomness = self.oracle.get_random_value_for_round(round);
+            // Based on `randomness` determine if the bet was won or lost. Pay out rewards to the user, etc.
+            match randomness {
+                Some(randomness) => {
+                    if self.is_victorious(randomness) {
+                        self.pay_reward(user)?;
+                    }
+                },
+                None => {
+                    // After registering bet, user would need to wait a couple of blocks for randomness
+                    return Err(Error::BetResolutionTooEarly);
+                }
+            }
+
+            self.bets.remove(bet_id);
+
+            Ok(())
+        }
+
+        fn get_id(&self) -> BetId {
+            // implement id generation
+            42
+        }
+
+        fn pay_fee(&self, user: User) -> Result<(), Error> {
+            // implement fee payment
+            Ok(())
+        }
+
+        fn is_victorious(&self, randomness: Vec<u8>) -> bool {
+            // implement victory logics
+            true
+        }
+
+        fn pay_reward(&self, user: User) -> Result<(), Error> {
+            //implement reward payment
+            Ok(())
+        }
+    }
+}

--- a/oracle-randomness-getter/Cargo.toml
+++ b/oracle-randomness-getter/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dia-oracle-randomness-getter"
+version = "0.1.0"
+authors = ["nnn-gif nitin.gurbani@diadata.org"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4.3.0", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2.6", default-features = false, features = [
+    "derive",
+], optional = true }
+
+dia-oracle-randomness-type = { path = "../oracle-randomness-type", default-features = false }
+
+
+[dev-dependencies]
+ink_e2e = "4.3.0"
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = ["ink/std", "scale/std", "scale-info/std","dia-oracle-randomness-type/std"]
+ink-as-dependency = []

--- a/oracle-randomness-getter/lib.rs
+++ b/oracle-randomness-getter/lib.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+use dia_oracle_randomness_type::RandomData;
+use ink::prelude::vec::Vec;
+use ink::primitives::AccountId;
+
+#[ink::trait_definition]
+pub trait RandomOracleGetter {
+    /// Retrieve the updater's account ID.
+    #[ink(message)]
+    fn get_updater(&self) -> AccountId;
+
+    /// Get the random value for a specific round, if it exists.
+    #[ink(message)]
+    fn get_random_value_for_round(&self, round: u64) -> Option<Vec<u8>>;
+
+    /// Get the complete RandomData for a specific round, if it exists.
+    #[ink(message)]
+    fn get_round(&self, round: u64) -> Option<RandomData>;
+
+    /// Get the latest round number.
+    #[ink(message)]
+    fn get_latest_round(&self) -> u64;
+}

--- a/oracle-randomness-setter/Cargo.toml
+++ b/oracle-randomness-setter/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dia-oracle-randomness-setter"
+version = "0.1.0"
+authors = ["nnn-gif nitin.gurbani@diadata.org"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4.3.0", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2.6", default-features = false, features = [
+    "derive",
+], optional = true }
+
+dia-oracle-randomness-type = { path = "../oracle-randomness-type", default-features = false }
+
+
+[dev-dependencies]
+ink_e2e = "4.3.0"
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = ["ink/std", "scale/std", "scale-info/std", "dia-oracle-randomness-type/std"]
+ink-as-dependency = []

--- a/oracle-randomness-setter/lib.rs
+++ b/oracle-randomness-setter/lib.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+use dia_oracle_randomness_type::RandomData;
+use ink::prelude::vec::Vec;
+use ink::primitives::AccountId;
+
+#[ink::trait_definition]
+pub trait RandomOracleSetter {
+    /// Transfer ownership of the contract to a new owner.
+    #[ink(message)]
+    fn transfer_ownership(&mut self, new_owner: AccountId);
+
+    /// Set the account ID of the updater.
+    #[ink(message)]
+    fn set_updater(&mut self, updater: AccountId);
+
+    /// Set the random value for a specific round.
+    #[ink(message)]
+    fn set_random_value(&mut self, round: u64, data: RandomData);
+
+    /// Set random values for multiple rounds.
+    #[ink(message)]
+    fn set_random_values(&mut self, rounds: Vec<(u64, RandomData)>);
+}

--- a/oracle-randomness-type/Cargo.toml
+++ b/oracle-randomness-type/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "dia-oracle-randomness-type"
+version = "0.1.0"
+authors = ["nnn-gif nitin.gurbani@diadata.org"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4.3.0", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2.6", default-features = false, features = [
+    "derive",
+], optional = true }
+
+ 
+
+[dev-dependencies]
+ink_e2e = "4.3.0"
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = ["ink/std", "scale/std", "scale-info/std"]
+ink-as-dependency = []

--- a/oracle-randomness-type/lib.rs
+++ b/oracle-randomness-type/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+use ink::prelude::vec::Vec;
+
+#[derive(PartialEq, Debug, Clone, scale::Encode, scale::Decode)]
+#[cfg_attr(
+    feature = "std",
+    derive(scale_info::TypeInfo, ::ink::storage::traits::StorageLayout)
+)]
+pub struct RandomData {
+    /// A vector of bytes representing the randomness data.
+    pub randomness: Vec<u8>,
+}


### PR DESCRIPTION
Many ink! developers seek a way to use randomness in their contracts. This is quite tricky and often leads them to unsafe designs. This example is meant to demonstrate the idea of randomness with late reveal, where the contracts uses randomness that is generated "in the future" to guarantee unpredictability.